### PR TITLE
Adding missing types for Validator Component

### DIFF
--- a/src/@types/react-form-validator-core/index.d.ts
+++ b/src/@types/react-form-validator-core/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'react-form-validator-core' {
+    export class ValidatorComponent extends React.Component<any> {
+        public getErrorMessage(): string;
+    }
+}


### PR DESCRIPTION
Types for react-form-validator-core package don't exist. I needed to create a simple index.d.ts file for it so that we avoid build errors.