### PR TITLE
Added missing uno-js dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "react-router-dom": "^5.1.2",
     "react-router-hash-link": "^1.2.2",
     "ts-jest": "^24.2.0",
-    "typescript": "^3.7.3"
+    "typescript": "^3.7.3",
+    "uno-js": "^0.3.1"
   },
   "dependencies": {
     "@material-ui/core": "^4.8.0",


### PR DESCRIPTION
This package requires uno-js dep. It was "working" because uno-react also is also depending on uno-js, but we need it as a direct dependency from this package.