### PR TITLE
Expose the `seconds` param

### DIFF
--- a/src/SnackbarService.tsx
+++ b/src/SnackbarService.tsx
@@ -13,7 +13,7 @@ class SnackbarService extends SimpleObservable {
         return this.snackbar;
     }
 
-    public showSnackbar(message: string, type = 'success'): Promise<{}> {
+    public showSnackbar(message: string, type = 'success', seconds = 5000): Promise<{}> {
         return new Promise(() => {
             this.snackbar = {
                 isMobile: false,
@@ -21,7 +21,7 @@ class SnackbarService extends SimpleObservable {
                     messageText: message,
                     messageType: type,
                 },
-                seconds: 5000,
+                seconds,
             };
             this.inform();
         });


### PR DESCRIPTION
I realised the seconds param wasn't available via this API so figured I'd add it. Easy change, backwards compatible, figured it was worth a PR. :-)

Thanks for this package, super helpful to be able to send alerts from outside of a react component and have them displayed in Material UI. ❤️ 

I mentioned in the commit, I'd recommend renaming `seconds` to `milliseconds` as it seems like it's actually milliseconds and not seconds. I'd guess displaying an alert for 5k seconds is unlikely!