### PR TITLE
Export the `GlobalSnackbar`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ export * from './ButtonWithLoading';
 export * from './ConfirmationDialog';
 export * from './ErrorBoundary';
 export * from './FormModal';
+export * from './GlobalSnackbar';
 export * from './LoadingIcon';
 export * from './MenuList';
 export * from './NavBar';


### PR DESCRIPTION
After #270 was merged I updated and tried to import `MessageTypes` but it is not exported from the package. It's exported from the `GlobalSnackbar` file, but that file in turn is not exported. This PR adds it to the exports list, but this may not be the way you imagine solving this.

My use case is that I wanted to import the type, so I could have my own wrapping function which only accepts the correct types for the snackbar.